### PR TITLE
Removing second npm install call.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV NODE_ENV=production \
 EXPOSE 3000
 COPY . /build
 COPY --from=builder /patron-web/dist /patron-web/dist
+COPY --from=builder /patron-web/node_modules  /patron-web/node_modules
 COPY --from=builder /patron-web/lib  /patron-web/lib
 COPY --from=builder /patron-web/package*.json /patron-web/
 RUN /build/build.sh

--- a/build.sh
+++ b/build.sh
@@ -10,5 +10,3 @@ apk add --no-cache su-exec
 cp /build/entrypoint.sh /patron-web/entrypoint.sh
 cd /patron-web
 rm -R /build
-npm install --only=production
-

--- a/prebuild.sh
+++ b/prebuild.sh
@@ -9,4 +9,3 @@ git clone $1 --branch $2 --single-branch /patron-web
 cd /patron-web
 npm install
 npm run prepublish
-


### PR DESCRIPTION
It was mentioned that only the `dependencies` were trying to be installed through npm from `package.json` and not the `dev-dependencies` but both were being installed at first. It is needed to be able to compile the code to the `/dist` and `/lib` folders. This means that the second `npm install --only=production` is not needed. In order to use the packages, however, the `node_modules` folder has to be copied over.
It does take some time to copy over the files, but now there's only one `npm install` call.